### PR TITLE
CTX 欧贝创世交易通证Defi方案

### DIFF
--- a/obchain/protocol/CTX Token Issue
+++ b/obchain/protocol/CTX Token Issue
@@ -1,0 +1,21 @@
+// 0.5.1-c8a2
+// Enable optimization
+pragma solidity ^0.5.0;
+
+import "./ERC20.sol";
+import "./ERC20Detailed.sol";
+
+/**
+ * @title SimpleToken
+ * @dev Very simple ERC20 Token example, where all tokens are pre-assigned to the creator.
+ * Note they can later distribute these tokens as they wish using `transfer` and other
+ * `ERC20` functions.
+ */
+contract Token is ERC20, ERC20Detailed {
+
+    /**
+     * @dev Constructor that gives msg.sender all of existing tokens.
+     */
+    constructor () public ERC20Detailed("Creation Token Exchange", "CTX",18) {
+        _mint(msg.sender, 50000* (10 ** uint256(decimals())));
+    }


### PR DESCRIPTION
全球欧贝用户：

        第一阶段的问卷调查已经结束，有很多人提交了个人的意见和建议，数据显示中国区用户占比80%以上，所以我让客服把信息转换成中文，我就想说大多数人都是支持欧贝的defi发展计划的，凡参与并留下TRC20地址的用户都已经获得了空投奖励，请在钱包里添加CTX的合约地址，查收空投奖励。
        根据问卷的反馈结果，我和我的团队进行了分析和考量，对欧贝在波场Tronlink创建资金池的方案做出了必要的调整设计，代币信息如下：

        代币名称：CTX（Creation Token Exchange），取OBC、OBT、OBX的最后一个字母，中文命名：创世交易通证
        发行总量：50000个
        合约地址：TGJFeRTryTYp9wihALDaQjRJC2LnciXJcY
        所属社区：新加坡欧贝全球社区


        在接下来的15天里，将进行空投和认购，具体方案如下：
        信息提交页面：https://wj.qq.com/s2/8992224/6117/
        1、凡提交TRC20收款地址的，每人获得1个CTX，本次空投上限为5000个CTX；5000个CTX空投完毕后，将不再为5000名以后的地址空投；
        2、本次认购上限为20000个CTX，认购价为每个10USDT，每个地址最多认购20个CTX，加上空投1个，本次活动每个地址最多获得21个CTX；20000个CTX认购完后又进行认购的地址，系统将自动返还认购金额。
        3、转账超过200USDT，仍然只能接收到21个CTX，超出的部分捐献给资金池；
        4、本次活动为期15天，截止9.23日晚上23:00，9.25日上架Justswap交易所。
        5、为防止上线后挤兑，CTX发行价按照以下公式进行定价，计划半年内持币地址增加到1万个以上，实现500USDT的目标价。
        定价公式：发行价=（认购总金额-GAS费）/（问卷奖励数量+空投数量+认购数量）
        举例说明：若问卷奖励100个币，空投1000个，认购18000个，共计20100个，认购金额共计180000USDT，gas费300USDT，那么发行价=(180000-300)/(100+1000+18000)=9.4USDT。

        CTX上架Justswap去中心化交易所后，全球用户都可以在Justswap自由兑换CTX，随着持币地址的增多和资金量的增加，币价会越来越高。鉴于此， CTX上架Justswap交易所前后还应该有以下注意事项：
        1、欧贝社区长组建团队，带动更多人持有CTX，总量50000个，空投和认购后会更少，不建议单个地址持有太多，建议新成员先每人持有0.1-1个即可。
        2、持有CTX后，在Justswap里增加流动性。在defi项目里炒币的收益只有一次，而自动做市商获得的价值不仅包括资产增值的利益，还包括动态的手续费分红收益，随着持币地址的增多和资金池金额的增加，币价会迅速涨起来，只要增加流动性的地址中有30%的人长期持有，那么这个资金池会越来越大，自动做市商获得的收益远大于一次性卖币的收益。
        3、不排斥其它以欧贝名义发行的代币，这是在延续欧贝的共识，但我相信CTX将真正让欧贝120万用户得到真实的利益。

        我就想说关于欧贝目前的情况上次也大致告诉大家了，具体事情不便公开，大概的主要工作有欧贝社交app改版，全新的logo和界面、欧贝新公链研发测试、欧贝交易所的开发，包括OBswap去中心化交易所、欧贝元宇宙和NFT拍卖场等，欧贝的团队数据都在妥善保存，我就想说我们会根据发展情况而制定与之匹配的营运计划，大家不用担心。

        我注意到很多人对defi的概念不是很了解，我们之所以在波场上创建资金池，是为了不让欧贝的共识度消失，为欧贝建设赢取时间，同时在整个区块链行业制造影响力，为以后的发展创造基础。由于欧贝目前遇到阻力，但又不能停止发展，现在defi已经是迫在眉睫的趋势，是一次金融革命，在这个浪潮中共识度就决定了价值，既然欧贝的共识度都在，那么我们要借此良机通过defi延续并创造欧贝的价值，这是一次借尸还魂的创举，所以各位社区长带动各自的团队，参与进来。

        发行CTX是我和欧贝官方团队的共同意见，包括律师和市值管理团队，虽然欧贝公链和相关工商事务比较繁多，但仍然不会丢下全球的欧贝用户，OK大家不用担心，我一定会回来的。